### PR TITLE
Fix IRC_Send_NAMES not sending correct prefix for certain clients.

### DIFF
--- a/src/ngircd/irc-info.c
+++ b/src/ngircd/irc-info.c
@@ -1578,10 +1578,10 @@ IRC_Send_NAMES(CLIENT * Client, CHANNEL * Chan)
 		if (is_member || is_visible) {
 			if (str[strlen(str) - 1] != ':')
 				strlcat(str, " ", sizeof(str));
-			if (Client_Cap(cl) & CLIENT_CAP_MULTI_PREFIX) {
-				if (strchr(Channel_UserModes(Chan, cl), 'o') &&
-				    strchr(Channel_UserModes(Chan, cl), 'v'))
-					strlcat(str, "@+", sizeof(str));
+			if (Client_Cap(cl) & CLIENT_CAP_MULTI_PREFIX && 
+					strchr(Channel_UserModes(Chan, cl), 'o') &&
+					strchr(Channel_UserModes(Chan, cl), 'v')) {
+				strlcat(str, "@+", sizeof(str));
 			} else {
 				if (strchr(Channel_UserModes(Chan, cl), 'o'))
 					strlcat(str, "@", sizeof(str));


### PR DESCRIPTION
Two fixes here: IRC_Send_NAMES was checking the capability of the
wrong client when responding, and it didn't return any prefix for
clients that had either +v or +o but not both.
