### PR TITLE
Show account name in WHOIS

### DIFF
--- a/src/ngircd/irc-info.c
+++ b/src/ngircd/irc-info.c
@@ -401,6 +401,13 @@ IRC_WHOIS_SendReply(CLIENT *Client, CLIENT *from, CLIENT *c)
 				Client_ID(from), Client_ID(c)))
 		return DISCONNECTED;
 
+	/* Account name metadata? */
+	if (Client_AccountName(c) &&
+	    !IRC_WriteStrClient(from, RPL_WHOISLOGGEDIN_MSG,
+				Client_ID(from), Client_ID(c),
+				Client_AccountName(c)))
+		return DISCONNECTED;
+
 	/* Local client and requester is the user itself or an IRC Op? */
 	if (Client_Conn(c) > NONE &&
 	    (from == c || (!Conf_MorePrivacy && Client_HasMode(from, 'o')))) {

--- a/src/ngircd/messages.h
+++ b/src/ngircd/messages.h
@@ -71,6 +71,7 @@
 #define RPL_LISTEND_MSG			"323 %s :End of LIST"
 #define RPL_CHANNELMODEIS_MSG		"324 %s %s +%s"
 #define RPL_CREATIONTIME_MSG		"329 %s %s %ld"
+#define RPL_WHOISLOGGEDIN_MSG		"330 %s %s %s :is logged in as"
 #define RPL_NOTOPIC_MSG			"331 %s %s :No topic is set"
 #define RPL_TOPIC_MSG			"332 %s %s :%s"
 #define RPL_TOPICSETBY_MSG		"333 %s %s %s %u"


### PR DESCRIPTION
This uses the same numeric as Charybdis and ircu families.

atheme/atheme#259 adds support for this to Atheme services.
