### PR TITLE
Updated RPL_CREATED message to conform to RFC 2812

### DIFF
--- a/src/ngircd/messages.h
+++ b/src/ngircd/messages.h
@@ -19,7 +19,7 @@
 
 #define RPL_WELCOME_MSG			"001 %s :Welcome to the Internet Relay Network %s"
 #define RPL_YOURHOST_MSG		"002 %s :Your host is %s, running version ngircd-%s (%s/%s/%s)"
-#define RPL_CREATED_MSG			"003 %s :This server has been started %s"
+#define RPL_CREATED_MSG			"003 %s :This server was created %s"
 #define RPL_MYINFO_MSG			"004 %s %s ngircd-%s %s %s"
 #define RPL_ISUPPORTNET_MSG		"005 %s NETWORK=%s :is my network name"
 #define RPL_ISUPPORT1_MSG		"005 %s RFC2812 IRCD=ngIRCd CHARSET=UTF-8 CASEMAPPING=ascii PREFIX=(qaohv)~&@%%+ CHANTYPES=%s CHANMODES=beI,k,l,imMnOPQRstVz CHANLIMIT=%s:%d :are supported on this server"


### PR DESCRIPTION
According to the [RFC 2812 section 5.1](https://tools.ietf.org/html/rfc2812#section-5.1) the RPL_CREATED message should be "This server was created \<date\>" and not "This server has been started \<date\>".