### PR TITLE
Specify session context for OpenSSL clients

### DIFF
--- a/src/ngircd/conn-ssl.c
+++ b/src/ngircd/conn-ssl.c
@@ -317,6 +317,7 @@ ConnSSL_InitLibrary( void )
 		goto out;
 	}
 
+	SSL_CTX_set_session_id_context(newctx, (unsigned char *)"ngircd", 6);
 	SSL_CTX_set_options(newctx, SSL_OP_SINGLE_DH_USE|SSL_OP_NO_SSLv2);
 	SSL_CTX_set_mode(newctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
 	SSL_CTX_set_verify(newctx, SSL_VERIFY_PEER|SSL_VERIFY_CLIENT_ONCE,


### PR DESCRIPTION
Reconnecting to ngIRCd 22.1 built with OpenSSL with some OpenSSL
clients, including Pidgin and stunnel 5.06, attempts to reuse a session
and fails due to the absence of this line.

The error message in syslog from ngIRCd is:

> SSL protocol error: SSL_accept (error:140D9115:SSL
> routines:SSL_GET_PREV_SESSION:session id context uninitialized)

This patch appears to fix the problem for both Pidgin and stunnel; it
may work for other OpenSSL clients that attempt to re-use sessions.

*   <https://github.com/ngircd/ngircd/issues/182>
*   <https://developer.pidgin.im/ticket/11568>
*   <https://www.openssl.org/docs/ssl/SSL_CTX_set_session_id_context.html>