### PR TITLE
Use "NOTICE *" before registration instead of "NOTICE AUTH".

### DIFF
--- a/doc/sample-ngircd.conf.tmpl
+++ b/doc/sample-ngircd.conf.tmpl
@@ -195,7 +195,7 @@
 	# Normally ngIRCd doesn't send any messages to a client until it is
 	# registered. Enable this option to let the daemon send "NOTICE *"
 	# messages to clients while connecting.
-	;NoticeAuth = no
+	;NoticeBeforeRegistration = no
 
 	# Should IRC Operators be allowed to use the MODE command even if
 	# they are not(!) channel-operators?

--- a/doc/sample-ngircd.conf.tmpl
+++ b/doc/sample-ngircd.conf.tmpl
@@ -193,7 +193,7 @@
 	;MorePrivacy = no
 
 	# Normally ngIRCd doesn't send any messages to a client until it is
-	# registered. Enable this option to let the daemon send "NOTICE AUTH"
+	# registered. Enable this option to let the daemon send "NOTICE *"
 	# messages to clients while connecting.
 	;NoticeAuth = no
 

--- a/man/ngircd.conf.5.tmpl
+++ b/man/ngircd.conf.5.tmpl
@@ -299,7 +299,7 @@ anonymizing software such as TOR or I2P and one does not wish to make it
 too easy to collect statistics on the users.
 Default: no.
 .TP
-\fBNoticeAuth\fR (boolean)
+\fBNoticeBeforeRegistration\fR (boolean)
 Normally ngIRCd doesn't send any messages to a client until it is registered.
 Enable this option to let the daemon send "NOTICE *" messages to clients
 while connecting. Default: no.

--- a/man/ngircd.conf.5.tmpl
+++ b/man/ngircd.conf.5.tmpl
@@ -301,7 +301,7 @@ Default: no.
 .TP
 \fBNoticeAuth\fR (boolean)
 Normally ngIRCd doesn't send any messages to a client until it is registered.
-Enable this option to let the daemon send "NOTICE AUTH" messages to clients
+Enable this option to let the daemon send "NOTICE *" messages to clients
 while connecting. Default: no.
 .TP
 \fBOperCanUseMode\fR (boolean)

--- a/src/ngircd/conf.c
+++ b/src/ngircd/conf.c
@@ -412,7 +412,7 @@ Conf_Test( void )
 #endif
 	printf("  IncludeDir = %s\n", Conf_IncludeDir);
 	printf("  MorePrivacy = %s\n", yesno_to_str(Conf_MorePrivacy));
-	printf("  NoticeAuth = %s\n", yesno_to_str(Conf_NoticeAuth));
+	printf("  NoticeBeforeRegistration = %s\n", yesno_to_str(Conf_NoticeBeforeRegistration));
 	printf("  OperCanUseMode = %s\n", yesno_to_str(Conf_OperCanMode));
 	printf("  OperChanPAutoOp = %s\n", yesno_to_str(Conf_OperChanPAutoOp));
 	printf("  OperServerMode = %s\n", yesno_to_str(Conf_OperServerMode));
@@ -797,7 +797,7 @@ Set_Defaults(bool InitServers)
 #endif
 	strcpy(Conf_IncludeDir, "");
 	Conf_MorePrivacy = false;
-	Conf_NoticeAuth = false;
+	Conf_NoticeBeforeRegistration = false;
 	Conf_OperCanMode = false;
 	Conf_OperChanPAutoOp = true;
 	Conf_OperServerMode = false;
@@ -1796,8 +1796,8 @@ Handle_OPTIONS(const char *File, int Line, char *Var, char *Arg)
 		Conf_MorePrivacy = Check_ArgIsTrue(Arg);
 		return;
 	}
-	if (strcasecmp(Var, "NoticeAuth") == 0) {
-		Conf_NoticeAuth = Check_ArgIsTrue(Arg);
+	if (strcasecmp(Var, "NoticeBeforeRegistration") == 0 || strcasecmp(Var, "NoticeAuth") == 0) {
+		Conf_NoticeBeforeRegistration = Check_ArgIsTrue(Arg);
 		return;
 	}
 	if (strcasecmp(Var, "OperCanUseMode") == 0) {

--- a/src/ngircd/conf.h
+++ b/src/ngircd/conf.h
@@ -195,7 +195,7 @@ GLOBAL bool Conf_Ident;
 GLOBAL bool Conf_MorePrivacy;
 
 /** Enable "NOTICE *" messages on connect */
-GLOBAL bool Conf_NoticeAuth;
+GLOBAL bool Conf_NoticeBeforeRegistration;
 
 /** Enable all usage of PAM, even when compiled with support for it */
 GLOBAL bool Conf_PAM;

--- a/src/ngircd/conf.h
+++ b/src/ngircd/conf.h
@@ -194,7 +194,7 @@ GLOBAL bool Conf_Ident;
 /** Enable "more privacy" mode and "censor" some user-related information */
 GLOBAL bool Conf_MorePrivacy;
 
-/** Enable NOTICE AUTH messages on connect */
+/** Enable "NOTICE *" messages on connect */
 GLOBAL bool Conf_NoticeAuth;
 
 /** Enable all usage of PAM, even when compiled with support for it */

--- a/src/ngircd/conn.c
+++ b/src/ngircd/conn.c
@@ -1487,7 +1487,7 @@ Conn_StartLogin(CONN_ID Idx)
 		ident_sock = My_Connections[Idx].sock;
 #endif
 
-	if (Conf_NoticeAuth) {
+	if (Conf_NoticeBeforeRegistration) {
 		/* Send "NOTICE *" messages to the client */
 #ifdef IDENTAUTH
 		if (Conf_Ident)
@@ -2265,7 +2265,7 @@ cb_Read_Resolver_Result( int r_fd, UNUSED short events )
 		strlcpy(My_Connections[i].host, readbuf,
 			sizeof(My_Connections[i].host));
 		Client_SetHostname(c, readbuf);
-		if (Conf_NoticeAuth)
+		if (Conf_NoticeBeforeRegistration)
 			(void)Conn_WriteStr(i,
 					"NOTICE * :*** Found your hostname: %s",
 					My_Connections[i].host);
@@ -2291,7 +2291,7 @@ cb_Read_Resolver_Result( int r_fd, UNUSED short events )
 				    i, identptr);
 				Client_SetUser(c, identptr, true);
 			}
-			if (Conf_NoticeAuth) {
+			if (Conf_NoticeBeforeRegistration) {
 				(void)Conn_WriteStr(i,
 					"NOTICE * :*** Got %sident response%s%s",
 					*ptr ? "invalid " : "",
@@ -2300,13 +2300,13 @@ cb_Read_Resolver_Result( int r_fd, UNUSED short events )
 			}
 		} else if(Conf_Ident) {
 			Log(LOG_INFO, "IDENT lookup for connection %d: no result.", i);
-			if (Conf_NoticeAuth)
+			if (Conf_NoticeBeforeRegistration)
 				(void)Conn_WriteStr(i,
 					"NOTICE * :*** No ident response");
 		}
 #endif
 
-		if (Conf_NoticeAuth) {
+		if (Conf_NoticeBeforeRegistration) {
 			/* Send buffered data to the client, but break on
 			 * errors because Handle_Write() would have closed
 			 * the connection again in this case! */

--- a/src/ngircd/conn.c
+++ b/src/ngircd/conn.c
@@ -1488,15 +1488,15 @@ Conn_StartLogin(CONN_ID Idx)
 #endif
 
 	if (Conf_NoticeAuth) {
-		/* Send "NOTICE AUTH" messages to the client */
+		/* Send "NOTICE *" messages to the client */
 #ifdef IDENTAUTH
 		if (Conf_Ident)
 			(void)Conn_WriteStr(Idx,
-				"NOTICE AUTH :*** Looking up your hostname and checking ident");
+				"NOTICE * :*** Looking up your hostname and checking ident");
 		else
 #endif
 			(void)Conn_WriteStr(Idx,
-				"NOTICE AUTH :*** Looking up your hostname");
+				"NOTICE * :*** Looking up your hostname");
 		/* Send buffered data to the client, but break on errors
 		 * because Handle_Write() would have closed the connection
 		 * again in this case! */
@@ -2267,7 +2267,7 @@ cb_Read_Resolver_Result( int r_fd, UNUSED short events )
 		Client_SetHostname(c, readbuf);
 		if (Conf_NoticeAuth)
 			(void)Conn_WriteStr(i,
-					"NOTICE AUTH :*** Found your hostname: %s",
+					"NOTICE * :*** Found your hostname: %s",
 					My_Connections[i].host);
 #ifdef IDENTAUTH
 		++identptr;
@@ -2293,7 +2293,7 @@ cb_Read_Resolver_Result( int r_fd, UNUSED short events )
 			}
 			if (Conf_NoticeAuth) {
 				(void)Conn_WriteStr(i,
-					"NOTICE AUTH :*** Got %sident response%s%s",
+					"NOTICE * :*** Got %sident response%s%s",
 					*ptr ? "invalid " : "",
 					*ptr ? "" : ": ",
 					*ptr ? "" : identptr);
@@ -2302,7 +2302,7 @@ cb_Read_Resolver_Result( int r_fd, UNUSED short events )
 			Log(LOG_INFO, "IDENT lookup for connection %d: no result.", i);
 			if (Conf_NoticeAuth)
 				(void)Conn_WriteStr(i,
-					"NOTICE AUTH :*** No ident response");
+					"NOTICE * :*** No ident response");
 		}
 #endif
 


### PR DESCRIPTION
AUTH is a valid nickname so sending notices to it is probably not a good idea. Use * as the target instead as done with numerics when the nick is not available.

This mimics the behaviour in Charybdis, IRCD-Hybrid, InspIRCd 2.2, Plexus 4, Unreal 3.4, etc.