### PR TITLE
Add PAMServiceName setting to specify the used PAM configuration

### DIFF
--- a/doc/sample-ngircd.conf.tmpl
+++ b/doc/sample-ngircd.conf.tmpl
@@ -226,6 +226,15 @@
 	# character prepended to their respective user names!
 	;PAMIsOptional = no
 
+	# When PAM is enabled, this value determines the used PAM
+	# configuration.
+	# This setting allows to run multiple ngIRCd instances with
+	# different PAM configurations on each instance.
+	# If you set it to "ngircd-foo", PAM will use
+	# /etc/pam.d/ngircd-foo instead of the default
+	# /etc/pam.d/ngircd.
+	;PAMServiceName = ngircd
+
 	# Let ngIRCd send an "authentication PING" when a new client connects,
 	# and register this client only after receiving the corresponding
 	# "PONG" reply.

--- a/man/ngircd.conf.5.tmpl
+++ b/man/ngircd.conf.5.tmpl
@@ -339,6 +339,14 @@ able to distinguish between Ident'ified and PAM-authenticated users: both
 don't have a "~" character prepended to their respective user names!
 Default: no.
 .TP
+\fBPAMServiceName\fR (string)
+When PAM is enabled, this value determines the used PAM configuration.
+This setting allows to run multiple ngIRCd instances with different
+PAM configurations on each instance. If you set it to "ngircd-foo",
+PAM will use /etc/pam.d/ngircd-foo instead of the default
+/etc/pam.d/ngircd.
+Default: ngircd.
+.TP
 \fBRequireAuthPing\fR (boolean)
 Let ngIRCd send an "authentication PING" when a new client connects, and
 register this client only after receiving the corresponding "PONG" reply.

--- a/src/ngircd/conf.c
+++ b/src/ngircd/conf.c
@@ -419,6 +419,7 @@ Conf_Test( void )
 #ifdef PAM
 	printf("  PAM = %s\n", yesno_to_str(Conf_PAM));
 	printf("  PAMIsOptional = %s\n", yesno_to_str(Conf_PAMIsOptional));
+	printf("  PAMServiceName = %s\n", Conf_PAMServiceName);
 #endif
 #ifndef STRICT_RFC
 	printf("  RequireAuthPing = %s\n", yesno_to_str(Conf_AuthPing));
@@ -807,6 +808,7 @@ Set_Defaults(bool InitServers)
 	Conf_PAM = false;
 #endif
 	Conf_PAMIsOptional = false;
+	strcpy(Conf_PAMServiceName, "ngircd");
 	Conf_ScrubCTCP = false;
 #ifdef SYSLOG
 #ifdef LOG_LOCAL5
@@ -1831,6 +1833,12 @@ Handle_OPTIONS(const char *File, int Line, char *Var, char *Arg)
 	}
 	if (strcasecmp(Var, "PAMIsOptional") == 0 ) {
 		Conf_PAMIsOptional = Check_ArgIsTrue(Arg);
+		return;
+	}
+	if (strcasecmp(Var, "PAMServiceName") == 0) {
+		len = strlcpy(Conf_PAMServiceName, Arg, sizeof(Conf_PAMServiceName));
+		if (len >= sizeof(Conf_PAMServiceName))
+			Config_Error_TooLong(File, Line, Var);
 		return;
 	}
 	if (strcasecmp(Var, "PredefChannelsOnly") == 0) {

--- a/src/ngircd/conf.h
+++ b/src/ngircd/conf.h
@@ -203,6 +203,9 @@ GLOBAL bool Conf_PAM;
 /** Don't require all clients to send a password an to be PAM authenticated */
 GLOBAL bool Conf_PAMIsOptional;
 
+/** The service name to use for PAM */
+GLOBAL char Conf_PAMServiceName[MAX_PAM_SERVICE_NAME_LEN];
+
 /** Disable all CTCP commands except for /me ? */
 GLOBAL bool Conf_ScrubCTCP;
 

--- a/src/ngircd/defines.h
+++ b/src/ngircd/defines.h
@@ -61,6 +61,9 @@
 /** Size of default connection pool. */
 #define CONNECTION_POOL 100
 
+/** Size of buffer for PAM service name. */
+#define MAX_PAM_SERVICE_NAME_LEN 64
+
 
 /* Hard-coded (default) options */
 

--- a/src/ngircd/pam.c
+++ b/src/ngircd/pam.c
@@ -32,6 +32,7 @@
 #include "log.h"
 #include "conn.h"
 #include "client.h"
+#include "conf.h"
 
 #include "pam.h"
 
@@ -101,7 +102,7 @@ PAM_Authenticate(CLIENT *Client) {
 	conv.appdata_ptr = Conn_Password(Client_Conn(Client));
 
 	/* Initialize PAM */
-	retval = pam_start("ngircd", Client_OrigUser(Client), &conv, &pam);
+	retval = pam_start(Conf_PAMServiceName, Client_OrigUser(Client), &conv, &pam);
 	if (retval != PAM_SUCCESS) {
 		Log(LOG_ERR, "PAM: Failed to create authenticator! (%d)", retval);
 		return false;


### PR DESCRIPTION
This setting allows to run multiple ngIRCd instances with
separate PAM configurations on each instance.
If one sets it to `ngircd-foo`, PAM will use `/etc/pam.d/ngircd-foo`
instead of the default `/etc/pam.d/ngircd`.