### PR TITLE
Fix Get_Error usage

### DIFF
--- a/src/ngircd/resolve.c
+++ b/src/ngircd/resolve.c
@@ -108,9 +108,7 @@ Resolve_Name( PROC_STAT *s, const char *Host, void (*cbfunc)(int, short))
 	return false;
 } /* Resolve_Name */
 
-
-#if !defined(HAVE_GETADDRINFO) || !defined(HAVE_GETNAMEINFO)
-#if !defined(WANT_IPV6) && defined(h_errno)
+#ifdef h_errno
 static char *
 Get_Error( int H_Error )
 {
@@ -127,7 +125,6 @@ Get_Error( int H_Error )
 	}
 	return "unknown error";
 }
-#endif
 #endif
 
 


### PR DESCRIPTION
The usage of Get_Error is guarded by "ifdef h_errno" in this file, the
definition of this function should follow the same rules.

Fixes a build error when cross-compiling:
https://github.com/ngircd/ngircd/issues/223