### PR TITLE
Change the length of the valid MotdPhrase

### DIFF
--- a/doc/sample-ngircd.conf.tmpl
+++ b/doc/sample-ngircd.conf.tmpl
@@ -51,7 +51,7 @@
 	# be shown to all users connecting to the server:
 	;MotdFile = :ETCDIR:/ngircd.motd
 
-	# A simple Phrase (<128 chars) if you don't want to use a motd file.
+	# A simple Phrase (<127 chars) if you don't want to use a motd file.
 	;MotdPhrase = "Hello world!"
 
 	# The name of the IRC network to which this server belongs. This name

--- a/doc/sample-ngircd.conf.tmpl
+++ b/doc/sample-ngircd.conf.tmpl
@@ -51,7 +51,7 @@
 	# be shown to all users connecting to the server:
 	;MotdFile = :ETCDIR:/ngircd.motd
 
-	# A simple Phrase (<256 chars) if you don't want to use a motd file.
+	# A simple Phrase (<128 chars) if you don't want to use a motd file.
 	;MotdPhrase = "Hello world!"
 
 	# The name of the IRC network to which this server belongs. This name

--- a/man/ngircd.conf.5.tmpl
+++ b/man/ngircd.conf.5.tmpl
@@ -125,7 +125,7 @@ take effect when ngircd starts up or is instructed to re-read its
 configuration file.
 .TP
 \fBMotdPhrase\fR (string)
-A simple Phrase (<256 chars) if you don't want to use a MOTD file.
+A simple Phrase (<127 chars) if you don't want to use a MOTD file.
 .TP
 \fBNetwork\fR (string)
 The name of the IRC network to which this server belongs. This name is


### PR DESCRIPTION
According to the source code, it is now 128 characters.
https://github.com/ngircd/ngircd/blob/master/src/ngircd/conf.c#L1487

I didn't look through the history to see when the change happened. I just happened to find during a migration that my 140 character MOTD didn't work.