### PR TITLE
Update install documentation: libgnutls-dev

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -174,7 +174,7 @@ build the sources including all optional features and to run the test suite:
 * Debian / Ubuntu based distributions:
 
   apt-get install \
-    autoconf automake build-essential expect libgnutls-dev \
+    autoconf automake build-essential expect libgnutls28-dev \
     libident-dev libpam-dev pkg-config libwrap0-dev libz-dev telnet
 
 


### PR DESCRIPTION
According https://packages.debian.org/search?keywords=libgnutls28-dev in Ubuntu and Debian libgnutls-dev package name is libgnutls28-dev