### PR TITLE
*/Makefile.am: Replace make with ${MAKE}

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,13 +23,13 @@ maintainer-clean-local:
 	rm -f config.log debian
 
 testsuite:
-	cd src/testsuite && make check
+	cd src/testsuite && ${MAKE} check
 
 lint:
-	cd src/ngircd && make lint
+	cd src/ngircd && ${MAKE} lint
 
 srcdoc:
-	cd doc && make srcdoc
+	cd doc && ${MAKE} srcdoc
 
 have-xcodebuild:
 	@xcodebuild -project contrib/MacOSX/ngIRCd.xcodeproj -list \
@@ -64,7 +64,7 @@ osxpkg: have-packagemaker osxpkg-dest
 	 --out ../../$(distdir).mpkg
 	rm -f $(distdir).mpkg.zip
 	zip -ro9 $(distdir).mpkg.zip $(distdir).mpkg
-	make osxpkg-clean
+	${MAKE} osxpkg-clean
 
 osxpkg-clean:
 	[ ! -r ngircd.dest ] || sudo -n rm -rf ngircd.dest
@@ -72,12 +72,12 @@ osxpkg-clean:
 
 osxpkg-dest: have-xcodebuild osxpkg-clean clean
 	./configure --prefix=/opt/ngircd
-	make xcode
-	make -C contrib/MacOSX de.barton.ngircd.plist
+	${MAKE} xcode
+	${MAKE} -C contrib/MacOSX de.barton.ngircd.plist
 	mkdir -p ngircd.dest/opt/ngircd/sbin
-	DESTDIR="$$PWD/ngircd.dest" make -C doc install
-	DESTDIR="$$PWD/ngircd.dest" make -C contrib install
-	DESTDIR="$$PWD/ngircd.dest" make -C man install
+	DESTDIR="$$PWD/ngircd.dest" ${MAKE} -C doc install
+	DESTDIR="$$PWD/ngircd.dest" ${MAKE} -C contrib install
+	DESTDIR="$$PWD/ngircd.dest" ${MAKE} -C man install
 	cp contrib/MacOSX/build/Default/ngIRCd \
 	 ngircd.dest/opt/ngircd/sbin/ngircd
 	rm ngircd.dest/opt/ngircd/etc/ngircd.conf

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -55,7 +55,7 @@ all: $(generated_docs)
 install-data-hook: $(static_docs) $(toplevel_docs) $(generated_docs)
 	$(MKDIR_P) -m 755 $(DESTDIR)$(sysconfdir)
 	@if [ ! -f $(DESTDIR)$(sysconfdir)/ngircd.conf ]; then \
-	  make install-config; \
+	  ${MAKE} install-config; \
 	 fi
 	$(MKDIR_P) -m 755 $(DESTDIR)$(docdir)
 	for f in $(static_docs) $(toplevel_docs); do \
@@ -75,7 +75,7 @@ install-config:
 uninstall-hook:
 	rm -rf $(DESTDIR)$(docdir)
 	@if cmp --silent sample-ngircd.conf $(DESTDIR)$(sysconfdir)/ngircd.conf; then \
-	  make uninstall-config; \
+	  ${MAKE} uninstall-config; \
 	 else \
 	  echo; \
 	  echo " ** NOTE: Not uninstalling changed configuration file:"; \
@@ -87,7 +87,7 @@ uninstall-config:
 	rm -f $(DESTDIR)$(sysconfdir)/ngircd.conf
 
 srcdoc:
-	make -C src srcdoc
+	${MAKE} -C src srcdoc
 
 .PHONY: install-config uninstall-config srcdoc
 


### PR DESCRIPTION
Fixes warnings such as:
"warning: jobserver unavailable: using -j1. Add `+' to parent make rule."

Signed-off-by: Sam James (sam_c) <sam@cmpct.info>