### PR TITLE
Handle commands in the read buffer before reading more data

### DIFF
--- a/src/ngircd/defines.h
+++ b/src/ngircd/defines.h
@@ -153,12 +153,6 @@
 /** Size of the read buffer of a connection in bytes. */
 #define READBUFFER_LEN 2048
 
-/** Maximum size of the read buffer of a connection in bytes. */
-#define READBUFFER_MAX_LEN 65535
-
-/** Maximum size of the read buffer of a server link connection in bytes. */
-#define READBUFFER_SLINK_LEN 65536
-
 /** Size that triggers write buffer flushing if more space is needed. */
 #define WRITEBUFFER_FLUSH_LEN 4096
 
@@ -166,7 +160,7 @@
 #define WRITEBUFFER_MAX_LEN 32768
 
 /** Maximum size of the write buffer of a server link connection in bytes. */
-#define WRITEBUFFER_SLINK_LEN READBUFFER_SLINK_LEN
+#define WRITEBUFFER_SLINK_LEN 65536
 
 
 /* IRC/IRC+ protocol */


### PR DESCRIPTION
If there are more bytes in the read buffer already than a single valid IRC command can get long (513 bytes, COMMAND_LEN), wait for this/those command(s) to be handled first and don't try to read even more data from the network (which most probably would overflow the read buffer of this connection soon). So don't enable the read event on this socket in the main loop.

And there is no point in waiting up to one second for the network receiving new data when there is still a read buffer which is holding at least one command; we shouldn't waste time but handle it immediately!