### PR TITLE
Client_Search: Avoid crash if Nick == NULL.

### DIFF
--- a/src/ngircd/client.c
+++ b/src/ngircd/client.c
@@ -601,7 +601,8 @@ Client_Search( const char *Nick )
 	CLIENT *c = NULL;
 	UINT32 search_hash;
 
-	assert( Nick != NULL );
+	if( Nick == NULL )
+		return NULL;
 
 	/* copy Nick and truncate hostmask if necessary */
 	strlcpy( search_id, Nick, sizeof( search_id ));


### PR DESCRIPTION
This crash was found using American Fuzzy Lop.

Build flags:

    ./configure --without-syslog --with-iconv CC=afl-clang

Run mode:

    ngircd -n -f src/testsuite/ngircd-test1.conf

Minimized input:

    PASS pwd1 0 0
    SERVER ngircd.test.server3 0
    SERVER 0 0 0 0

Stacktrace from gdb:

    #0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:65
    #1  0x000000000044ac19 in strlcpy (dst=0x7fffffffd120 "@", src=0x0, size=64) at strlcpy.c:59
    #2  0x000000000040f8eb in Client_Search (Nick=0x0) at client.c:605
    #3  0x0000000000440207 in IRC_SERVER (Client=0x47e6b0, Req=0x7fffffffd260) at irc-server.c:189
    #4  0x0000000000448d77 in Handle_Request (Idx=<optimized out>, Req=0x7fffffffd260) at parse.c:544
    #5  Parse_Request (Idx=7, Request=<optimized out>) at parse.c:267
    #6  0x000000000041f668 in Handle_Buffer (Idx=7) at conn.c:1783
    #7  0x00000000004215f9 in Read_Request (Idx=7) at conn.c:1616
    #8  cb_clientserver (sock=7, what=<optimized out>) at conn.c:296
    #9  0x0000000000425ad0 in io_docallback (fd=7, what=<optimized out>) at io.c:924
    #10 io_dispatch_epoll (tv=<optimized out>) at io.c:497
    #11 io_dispatch (tv=<optimized out>) at io.c:896
    #12 0x000000000041eddd in Conn_Handler () at conn.c:748
    #13 0x0000000000405499 in main (argc=<optimized out>, argv=<optimized out>) at ngircd.c:316