### PR TITLE
Avoid calling IRC_KillClient with Client == NULL

### DIFF
--- a/src/ngircd/irc-server.c
+++ b/src/ngircd/irc-server.c
@@ -288,7 +288,7 @@ IRC_NJOIN( CLIENT *Client, REQUEST *Req )
 			Log(LOG_ALERT,
 			    "Failed to join client \"%s\" to channel \"%s\" (NJOIN): killing it!",
 			    ptr, channame);
-			IRC_KillClient(NULL, NULL, ptr, "Internal NJOIN error!");
+			IRC_KillClient(Client, NULL, ptr, "Internal NJOIN error!");
 			Log(LOG_DEBUG, "... done.");
 			goto skip_njoin;
 		}


### PR DESCRIPTION
I'm not familiar enough with the ngircd codebase, so I am not entirely
sure if `Client` is the right variable to pass to `KillClient` or if
it should be `c` instead.

This crash (segfault) was found using American Fuzzy Lop.

Build flags:

    ./configure --without-syslog --with-iconv CC=afl-clang

Run mode:

    ngircd -n -f src/testsuite/ngircd-test1.conf

Manually inimized input:

    PASS pwd1 0210-IRC+ Cd|t0:CHLMSX P
    SERVER ngircd.test.server3 :on
    :ngi 376 ngircd.test.server
    :ngircd.test.server3 NICK NickNa.e 1 ~ locst 1 + :e
    :ngircd.test.server3  JOIN #Channel :e.eEN
    :ngircd.test.server3 NICK NickName 1 ~ locst 1 + :e
    :ngircd.test.server3 NJOIN #Channel :@NickNamE,,,ngircd.test.server3!d

Stacktrace:

    #0  Client_ID (Client=0x0) at client.c:707
    #1  0x000000000042570c in IRC_KillClient (Client=0x0, From=0x0,
        Nick=0x7fffffffd00c "ngircd.test.server3!d", Reason=<optimized out>) at irc.c:379
    #2  0x000000000044050a in IRC_NJOIN (Client=0x47d6b0, Req=0x7fffffffd260) at irc-server.c:291
    #3  0x0000000000447eb7 in Handle_Request (Idx=<optimized out>, Req=0x7fffffffd260) at parse.c:544
    #4  Parse_Request (Idx=7, Request=<optimized out>) at parse.c:267
    #5  0x000000000041e788 in Handle_Buffer (Idx=7) at conn.c:1817
    #6  0x00000000004206f9 in Read_Request (Idx=7) at conn.c:1650
    #7  cb_clientserver (sock=7, what=<optimized out>) at conn.c:297
    #8  0x0000000000424bd0 in io_docallback (fd=7, what=<optimized out>) at io.c:924
    #9  io_dispatch_epoll (tv=<optimized out>) at io.c:497
    #10 io_dispatch (tv=<optimized out>) at io.c:896
    #11 0x000000000041defd in Conn_Handler () at conn.c:766
    #12 0x0000000000405489 in main (argc=<optimized out>, argv=<optimized out>) at ngircd.c:317