### PR TITLE
Send NAMES list and topic to NJOINed users

### DIFF
--- a/src/ngircd/irc-server.c
+++ b/src/ngircd/irc-server.c
@@ -250,7 +250,7 @@ IRC_SERVER( CLIENT *Client, REQUEST *Req )
 GLOBAL bool
 IRC_NJOIN( CLIENT *Client, REQUEST *Req )
 {
-	char nick_in[COMMAND_LEN], nick_out[COMMAND_LEN], *channame, *ptr, modes[8];
+	char nick_in[COMMAND_LEN], nick_out[COMMAND_LEN], *channame, *ptr, modes[8], *topic;
 	bool is_owner, is_chanadmin, is_op, is_halfop, is_voiced;
 	CHANNEL *chan;
 	CLIENT *c;
@@ -319,6 +319,24 @@ IRC_NJOIN( CLIENT *Client, REQUEST *Req )
 		/* Announce client to the channel */
 		IRC_WriteStrChannelPrefix(Client, chan, c, false,
 					  "JOIN :%s", channame);
+
+		/* Send NAMES and to the joined user */
+		if(IRC_Send_NAMES(c, chan))
+			IRC_WriteStrClient(c, RPL_ENDOFNAMES_MSG, Client_ID(Client),
+				Channel_Name(chan));
+
+		/* Send topic to the joined user */
+		topic = Channel_Topic(chan);
+		assert(topic != NULL);
+		if (*topic) {
+			IRC_WriteStrClient(c, RPL_TOPIC_MSG, Client_ID(c), channame, topic);
+#ifndef STRICT_RFC
+			IRC_WriteStrClient(c, RPL_TOPICSETBY_MSG,
+				Client_ID(c), channame,
+				Channel_TopicWho(chan),
+				Channel_TopicTime(chan));
+#endif
+		}
 
 		/* Announce "channel user modes" to the channel, if any */
 		strlcpy(modes, Channel_UserModes(chan, c), sizeof(modes));

--- a/src/ngircd/irc-server.c
+++ b/src/ngircd/irc-server.c
@@ -320,22 +320,25 @@ IRC_NJOIN( CLIENT *Client, REQUEST *Req )
 		IRC_WriteStrChannelPrefix(Client, chan, c, false,
 					  "JOIN :%s", channame);
 
-		/* Send NAMES list to the joined user */
-		if(IRC_Send_NAMES(c, chan))
-			IRC_WriteStrClient(c, RPL_ENDOFNAMES_MSG, Client_ID(Client),
-				Channel_Name(chan));
+		/* If the client is connected to me... */
+		if(Client_Conn(c) != NONE) {
+			/* Send NAMES list to the joined user */
+			if(IRC_Send_NAMES(c, chan))
+				IRC_WriteStrClient(c, RPL_ENDOFNAMES_MSG, Client_ID(Client),
+					Channel_Name(chan));
 
-		/* Send topic to the joined user */
-		topic = Channel_Topic(chan);
-		assert(topic != NULL);
-		if (*topic) {
-			IRC_WriteStrClient(c, RPL_TOPIC_MSG, Client_ID(c), channame, topic);
+			/* Send topic to the joined user */
+			topic = Channel_Topic(chan);
+			assert(topic != NULL);
+			if (*topic) {
+				IRC_WriteStrClient(c, RPL_TOPIC_MSG, Client_ID(c), channame, topic);
 #ifndef STRICT_RFC
-			IRC_WriteStrClient(c, RPL_TOPICSETBY_MSG,
-				Client_ID(c), channame,
-				Channel_TopicWho(chan),
-				Channel_TopicTime(chan));
+				IRC_WriteStrClient(c, RPL_TOPICSETBY_MSG,
+					Client_ID(c), channame,
+					Channel_TopicWho(chan),
+					Channel_TopicTime(chan));
 #endif
+			}
 		}
 
 		/* Announce "channel user modes" to the channel, if any */

--- a/src/ngircd/irc-server.c
+++ b/src/ngircd/irc-server.c
@@ -320,7 +320,7 @@ IRC_NJOIN( CLIENT *Client, REQUEST *Req )
 		IRC_WriteStrChannelPrefix(Client, chan, c, false,
 					  "JOIN :%s", channame);
 
-		/* Send NAMES and to the joined user */
+		/* Send NAMES list to the joined user */
 		if(IRC_Send_NAMES(c, chan))
 			IRC_WriteStrClient(c, RPL_ENDOFNAMES_MSG, Client_ID(Client),
 				Channel_Name(chan));


### PR DESCRIPTION
I looked at the code for when clients voluntarily join a channel and added the same routine for clients that joined due to `NJOIN`. I tested with channels that have topics set, topics not set, multiple users, etc, everything appears to work fine and HexChat behaves properly now. I don't know what implications this would have in a network with multiple servers given `NJOIN` is probably meant for synchronization and not control. This is actually some of the first C code I've ever written... so I am of course open to suggestions. Thanks!