### PR TITLE
Option to use -n and still write to syslog

### DIFF
--- a/man/ngircd.8.tmpl
+++ b/man/ngircd.8.tmpl
@@ -53,6 +53,9 @@ Don't fork a child and don't detach from controlling terminal.
 All log messages go to the console and you can use CTRL-C to
 terminate the server.
 .TP
+\fB\-y\fR, \fB\-\-syslog\fR
+Write log messages to the syslog even when running in the foreground.
+.TP
 \fB\-p\fR, \fB\-\-passive\fR
 Disable automatic connections to other servers. You can use the IRC command
 CONNECT later on as IRC Operator to link this ngIRCd to other servers.

--- a/src/ngircd/log.c
+++ b/src/ngircd/log.c
@@ -63,7 +63,7 @@ Log_Message(int Level, const char *msg)
  * Initialitze logging.
  * This function is called before the configuration file is read in.
  *
- * @param Syslog_Mode Set to true if ngIRCd is running as daemon.
+ * @param Syslog_Mode Set to true if ngIRCd is configured to log to the syslog.
  */
 GLOBAL void
 Log_Init(bool Syslog_Mode)

--- a/src/ngircd/log.c
+++ b/src/ngircd/log.c
@@ -39,13 +39,13 @@
 
 #include "log.h"
 
-static bool Is_Daemon;
+static bool Use_Syslog;
 
 
 static void
 Log_Message(int Level, const char *msg)
 {
-	if (!Is_Daemon) {
+	if (!Use_Syslog) {
 		/* log to console */
 		fprintf(stdout, "[%ld:%d %4ld] %s\n", (long)getpid(), Level,
 				(long)(time(NULL) - NGIRCd_Start), msg);
@@ -63,12 +63,12 @@ Log_Message(int Level, const char *msg)
  * Initialitze logging.
  * This function is called before the configuration file is read in.
  *
- * @param Daemon_Mode Set to true if ngIRCd is running as daemon.
+ * @param Syslog_Mode Set to true if ngIRCd is running as daemon.
  */
 GLOBAL void
-Log_Init(bool Daemon_Mode)
+Log_Init(bool Syslog_Mode)
 {
-	Is_Daemon = Daemon_Mode;
+	Use_Syslog = Syslog_Mode;
 
 #ifdef SYSLOG
 #ifndef LOG_CONS     /* Kludge: mips-dec-ultrix4.5 has no LOG_CONS */

--- a/src/ngircd/log.h
+++ b/src/ngircd/log.h
@@ -32,7 +32,7 @@
 
 #define LOG_snotice 1024
 
-GLOBAL void Log_Init PARAMS(( bool Daemon_Mode ));
+GLOBAL void Log_Init PARAMS(( bool Syslog_Mode ));
 GLOBAL void Log_Exit PARAMS(( void ));
 
 GLOBAL void Log PARAMS(( int Level, const char *Format, ... ));

--- a/src/ngircd/ngircd.c
+++ b/src/ngircd/ngircd.c
@@ -143,6 +143,12 @@ main(int argc, const char *argv[])
 				ok = true;
 			}
 #endif
+#ifdef SYSLOG
+			if (strcmp(argv[i], "--syslog") == 0) {
+				NGIRCd_NoSyslog = false;
+				ok = true;
+			}
+#endif
 			if (strcmp(argv[i], "--version") == 0) {
 				Show_Version();
 				exit(0);
@@ -201,6 +207,12 @@ main(int argc, const char *argv[])
 					Show_Version();
 					exit(1);
 				}
+#ifdef SYSLOG
+				if (argv[i][n] == 'y') {
+					NGIRCd_NoSyslog = false;
+					ok = true;
+				}
+#endif
 
 				if (!ok) {
 					fprintf(stderr,
@@ -479,6 +491,9 @@ Show_Help( void )
 #endif
 	puts( "  -t, --configtest   read, validate and display configuration; then exit" );
 	puts( "  -V, --version      output version information and exit" );
+#ifdef SYSLOG
+	puts( "  -y, --syslog       log to syslog even when using -n" );
+#endif
 	puts( "  -h, --help         display this help and exit" );
 } /* Show_Help */
 

--- a/src/ngircd/ngircd.c
+++ b/src/ngircd/ngircd.c
@@ -74,7 +74,7 @@ GLOBAL int
 main(int argc, const char *argv[])
 {
 	bool ok, configtest = false;
-	bool NGIRCd_NoDaemon = false;
+	bool NGIRCd_NoDaemon = false, NGIRCd_NoSyslog = false;
 	int i;
 	size_t n;
 
@@ -130,6 +130,7 @@ main(int argc, const char *argv[])
 			}
 			if (strcmp(argv[i], "--nodaemon") == 0) {
 				NGIRCd_NoDaemon = true;
+				NGIRCd_NoSyslog = true;
 				ok = true;
 			}
 			if (strcmp(argv[i], "--passive") == 0) {
@@ -178,6 +179,7 @@ main(int argc, const char *argv[])
 
 				if (argv[i][n] == 'n') {
 					NGIRCd_NoDaemon = true;
+					NGIRCd_NoSyslog = true;
 					ok = true;
 				}
 				if (argv[i][n] == 'p') {
@@ -249,7 +251,7 @@ main(int argc, const char *argv[])
 		NGIRCd_SignalRestart = false;
 		NGIRCd_SignalQuit = false;
 
-		Log_Init(!NGIRCd_NoDaemon);
+		Log_Init(!NGIRCd_NoSyslog);
 		Random_Init();
 		Conf_Init();
 		Log_ReInit();

--- a/src/ngircd/ngircd.c
+++ b/src/ngircd/ngircd.c
@@ -492,7 +492,7 @@ Show_Help( void )
 	puts( "  -t, --configtest   read, validate and display configuration; then exit" );
 	puts( "  -V, --version      output version information and exit" );
 #ifdef SYSLOG
-	puts( "  -y, --syslog       log to syslog even when using -n" );
+	puts( "  -y, --syslog       log to syslog even when running in the foreground (-n)" );
 #endif
 	puts( "  -h, --help         display this help and exit" );
 } /* Show_Help */


### PR DESCRIPTION
I figured it would be best to preserve the current behaviour of `-n` / `--nodaemon`, so I added a new option `-y` / `--syslog` which overrides it. Fixes #294.