### PR TITLE
configure.ng: Include <string.h> for memset in WORKING_GETADDRINFO probe

### DIFF
--- a/configure.ng
+++ b/configure.ng
@@ -101,6 +101,7 @@ AC_DEFUN([WORKING_GETADDRINFO],[
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <string.h>
 int
 main(int argc, char **argv)
 {


### PR DESCRIPTION
Otherwise, the probe always fails with compilers which do not support implicit function declarations.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
