### PR TITLE
Return ERR_NOTEXTTOSEND on empty PRIVMSG content

### DIFF
--- a/src/ngircd/irc.c
+++ b/src/ngircd/irc.c
@@ -572,6 +572,13 @@ Send_Message(CLIENT * Client, REQUEST * Req, int ForceType, bool SendErrors)
 #endif
 		message = Req->argv[1];
 
+	if (message[0] == '\0') {
+		if (!SendErrors)
+			return CONNECTED;
+		return IRC_WriteErrClient(Client, ERR_NOTEXTTOSEND_MSG,
+					  Client_ID(Client));
+	}
+
 	/* handle msgtarget = msgto *("," msgto) */
 	currentTarget = strtok_r(currentTarget, ",", &strtok_last);
 	ngt_UpperStr(Req->command);


### PR DESCRIPTION
They are dropped further down the line anyway; and sending ERR_NOTEXTTOSEND early matches other servers' behavior.