### PR TITLE
testsuite: Pass -nameopt to openssl s_client.

### DIFF
--- a/src/testsuite/connect-ssl-cert1-test.e
+++ b/src/testsuite/connect-ssl-cert1-test.e
@@ -1,10 +1,10 @@
 # ngIRCd test suite
 # Server connect test
 
-spawn openssl s_client -quiet -connect 127.0.0.1:6790
+spawn openssl s_client -quiet -nameopt utf8,space_eq -connect 127.0.0.1:6790
 expect {
         timeout { exit 1 }
-        "*CN*=*my.first.domain.tld"
+        "*CN = my.first.domain.tld"
 }
 
 sleep 2

--- a/src/testsuite/connect-ssl-cert2-test.e
+++ b/src/testsuite/connect-ssl-cert2-test.e
@@ -1,10 +1,10 @@
 # ngIRCd test suite
 # Server connect test
 
-spawn openssl s_client -quiet -connect 127.0.0.1:6790
+spawn openssl s_client -quiet -nameopt utf8,space_eq -connect 127.0.0.1:6790
 expect {
         timeout { exit 1 }
-        "*CN*=*my.second.domain.tld"
+        "*CN = my.second.domain.tld"
 }
 
 sleep 2


### PR DESCRIPTION
The default value for the -nameopt option changed in OpenSSL 3.2 from `oneline' to `utf8'. The `oneline' option also included a space around the fields which is not the case for `utf8'. This means that
	CN = my.first.domain.tld

changed to

	CN=my.first.domain.tld

and is now longer recognized, leading to test failure. This can be fixed by either going back to `oneline' or keeping `utf8' and adding additionally `space_eq'. Anoter way would be to teach the expect that the space is optional.

Add explicit -nameopt option with `utf8,space_eq' which is understood by by OpenSSL 3.2 and earlier to make explicit. Remove the wildcard.