### PR TITLE
Fix chan symbol returned by RPL_NAMREPLY for secret channels

### DIFF
--- a/src/ngircd/irc-info.c
+++ b/src/ngircd/irc-info.c
@@ -817,8 +817,9 @@ IRC_NAMES( CLIENT *Client, REQUEST *Req )
 	}
 
 	/* Now print all clients which are not in any channel */
+	char* chan_symbol = Channel_HasMode(chan, 's') ? "@" : "=";
 	c = Client_First();
-	snprintf(rpl, sizeof(rpl), RPL_NAMREPLY_MSG, Client_ID(from), "*", "*");
+	snprintf(rpl, sizeof(rpl), RPL_NAMREPLY_MSG, Client_ID(from), chan_symbol, "*");
 	while (c) {
 		if (Client_Type(c) == CLIENT_USER
 		    && Channel_FirstChannelOf(c) == NULL
@@ -830,11 +831,11 @@ IRC_NAMES( CLIENT *Client, REQUEST *Req )
 			strlcat(rpl, Client_ID(c), sizeof(rpl));
 
 			if (strlen(rpl) > COMMAND_LEN - CLIENT_NICK_LEN - 4) {
-				/* Line is gwoing too long, send now */
+				/* Line is going too long, send now */
 				if (!IRC_WriteStrClient(from, "%s", rpl))
 					return DISCONNECTED;
 				snprintf(rpl, sizeof(rpl), RPL_NAMREPLY_MSG,
-					 Client_ID(from), "*", "*");
+					 Client_ID(from), chan_symbol, "*");
 			}
 		}
 		c = Client_Next(c);
@@ -1514,10 +1515,13 @@ IRC_Send_NAMES(CLIENT * Client, CHANNEL * Chan)
 		return CONNECTED;
 
 	/* Secret channel? */
-	if (!is_member && Channel_HasMode(Chan, 's'))
+	bool secret_channel = Channel_HasMode(Chan, 's');
+	if (!is_member && secret_channel)
 		return CONNECTED;
 
-	snprintf(str, sizeof(str), RPL_NAMREPLY_MSG, Client_ID(Client), "=",
+	char* chan_symbol = secret_channel ? "@" : "=";
+
+	snprintf(str, sizeof(str), RPL_NAMREPLY_MSG, Client_ID(Client), chan_symbol,
 		 Channel_Name(Chan));
 	cl2chan = Channel_FirstMember(Chan);
 	while (cl2chan) {
@@ -1540,7 +1544,7 @@ IRC_Send_NAMES(CLIENT * Client, CHANNEL * Chan)
 				if (!IRC_WriteStrClient(Client, "%s", str))
 					return DISCONNECTED;
 				snprintf(str, sizeof(str), RPL_NAMREPLY_MSG,
-					 Client_ID(Client), "=",
+					 Client_ID(Client), chan_symbol,
 					 Channel_Name(Chan));
 			}
 		}

--- a/src/ngircd/irc-info.c
+++ b/src/ngircd/irc-info.c
@@ -817,7 +817,7 @@ IRC_NAMES( CLIENT *Client, REQUEST *Req )
 	}
 
 	/* Now print all clients which are not in any channel */
-	char* chan_symbol = Channel_HasMode(chan, 's') ? "@" : "=";
+	char chan_symbol = Channel_HasMode(chan, 's') ? '@' : '=';
 	c = Client_First();
 	snprintf(rpl, sizeof(rpl), RPL_NAMREPLY_MSG, Client_ID(from), chan_symbol, "*");
 	while (c) {
@@ -1519,7 +1519,7 @@ IRC_Send_NAMES(CLIENT * Client, CHANNEL * Chan)
 	if (!is_member && secret_channel)
 		return CONNECTED;
 
-	char* chan_symbol = secret_channel ? "@" : "=";
+	char chan_symbol = secret_channel ? '@' : '=';
 
 	snprintf(str, sizeof(str), RPL_NAMREPLY_MSG, Client_ID(Client), chan_symbol,
 		 Channel_Name(Chan));

--- a/src/ngircd/irc-info.c
+++ b/src/ngircd/irc-info.c
@@ -817,9 +817,8 @@ IRC_NAMES( CLIENT *Client, REQUEST *Req )
 	}
 
 	/* Now print all clients which are not in any channel */
-	char chan_symbol = Channel_HasMode(chan, 's') ? '@' : '=';
 	c = Client_First();
-	snprintf(rpl, sizeof(rpl), RPL_NAMREPLY_MSG, Client_ID(from), chan_symbol, "*");
+	snprintf(rpl, sizeof(rpl), RPL_NAMREPLY_MSG, Client_ID(from), '*', "*");
 	while (c) {
 		if (Client_Type(c) == CLIENT_USER
 		    && Channel_FirstChannelOf(c) == NULL
@@ -835,7 +834,7 @@ IRC_NAMES( CLIENT *Client, REQUEST *Req )
 				if (!IRC_WriteStrClient(from, "%s", rpl))
 					return DISCONNECTED;
 				snprintf(rpl, sizeof(rpl), RPL_NAMREPLY_MSG,
-					 Client_ID(from), chan_symbol, "*");
+					 Client_ID(from), '*', "*");
 			}
 		}
 		c = Client_Next(c);

--- a/src/ngircd/irc-info.c
+++ b/src/ngircd/irc-info.c
@@ -1500,6 +1500,8 @@ IRC_Send_NAMES(CLIENT * Client, CHANNEL * Chan)
 	char str[COMMAND_LEN];
 	CL2CHAN *cl2chan;
 	CLIENT *cl;
+	bool secret_channel;
+	char chan_symbol;
 
 	assert(Client != NULL);
 	assert(Chan != NULL);
@@ -1514,11 +1516,11 @@ IRC_Send_NAMES(CLIENT * Client, CHANNEL * Chan)
 		return CONNECTED;
 
 	/* Secret channel? */
-	bool secret_channel = Channel_HasMode(Chan, 's');
+	secret_channel = Channel_HasMode(Chan, 's');
 	if (!is_member && secret_channel)
 		return CONNECTED;
 
-	char chan_symbol = secret_channel ? '@' : '=';
+	chan_symbol = secret_channel ? '@' : '=';
 
 	snprintf(str, sizeof(str), RPL_NAMREPLY_MSG, Client_ID(Client), chan_symbol,
 		 Channel_Name(Chan));

--- a/src/ngircd/messages.h
+++ b/src/ngircd/messages.h
@@ -84,7 +84,7 @@
 #define RPL_ENDOFEXCEPTLIST_MSG		"349 %s %s :End of channel exception list"
 #define RPL_VERSION_MSG			"351 %s %s-%s.%s %s :%s"
 #define RPL_WHOREPLY_MSG		"352 %s %s %s %s %s %s %s :%d %s"
-#define RPL_NAMREPLY_MSG		"353 %s %s %s :"
+#define RPL_NAMREPLY_MSG		"353 %s %c %s :"
 #define RPL_LINKS_MSG			"364 %s %s %s :%d %s"
 #define RPL_ENDOFLINKS_MSG		"365 %s %s :End of LINKS list"
 #define RPL_ENDOFNAMES_MSG		"366 %s %s :End of NAMES list"


### PR DESCRIPTION
Refs:

* https://modern.ircdocs.horse/#rplnamreply-353
* https://datatracker.ietf.org/doc/html/rfc2812#page-47
* (RFC 1459 is irrelevant here, as https://datatracker.ietf.org/doc/html/rfc1459#page-51 uses a different format)