### PR TITLE
Fix all remaining compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tags
 .*.swp
 .deps
 .trunk

--- a/configure.ng
+++ b/configure.ng
@@ -143,8 +143,6 @@ AC_DEFUN([GCC_W_NO_FORMAT_TRUNC],[
 
 if test "$GCC" = "yes"; then
 	# We are using the GNU C compiler. Good!
-	CFLAGS="$CFLAGS -pipe -W -Wall -Wpointer-arith -Wstrict-prototypes"
-
 	GCC_STACK_PROTECT_CC
 	GCC_W_NO_FORMAT_TRUNC
 fi
@@ -723,7 +721,8 @@ AC_DEFINE_UNQUOTED(HOST_OS, "$host_os" )
 
 # Add additional CFLAGS, LDFLAGS and LIBS which were specified on the command
 # line or by some tests from above, but after running this script. Useful for
-# adding "-Werror", for example:
+# adding "-march=native", for example:
+CFLAGS="$CFLAGS -pipe -Werror -Wall -Wextra -pedantic"
 test -n "$CFLAGS_END" && CFLAGS="$CFLAGS $CFLAGS_END"
 test -n "$LDFLAGS_END" && LDFLAGS="$LDFLAGS $LDFLAGS_END"
 test -n "$LIBS_END" && LIBS="$LIBS $LIBS_END"

--- a/src/ngircd/client.c
+++ b/src/ngircd/client.c
@@ -38,7 +38,7 @@
 #include "match.h"
 #include "messages.h"
 
-#define GETID_LEN (CLIENT_NICK_LEN-1) + 1 + (CLIENT_USER_LEN-1) + 1 + (CLIENT_HOST_LEN-1) + 1
+#define GETID_LEN (CLIENT_ID_LEN-1) + 1 + (CLIENT_USER_LEN-1) + 1 + (CLIENT_HOST_LEN-1) + 1
 
 static CLIENT *This_Server, *My_Clients;
 
@@ -925,7 +925,7 @@ Client_Mask( CLIENT *Client )
 	if (Client->type == CLIENT_SERVER)
 		return Client->id;
 
-	snprintf(Mask_Buffer, GETID_LEN, "%s!%s@%s",
+	snprintf(Mask_Buffer, sizeof(Mask_Buffer), "%s!%s@%s",
 		 Client->id, Client->user, Client->host);
 	return Mask_Buffer;
 } /* Client_Mask */

--- a/src/ngircd/conf-ssl.h
+++ b/src/ngircd/conf-ssl.h
@@ -12,11 +12,8 @@
 
 #ifdef HAVE_LIBSSL
 #define SSL_SUPPORT
+#define OPENSSL_NO_DEPRECATED
 #include <openssl/ssl.h>
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define OpenSSL_version SSLeay_version
-#define OPENSSL_VERSION SSLEAY_VERSION
-#endif
 #endif
 #ifdef HAVE_LIBGNUTLS
 #define SSL_SUPPORT

--- a/src/ngircd/ngircd.c
+++ b/src/ngircd/ngircd.c
@@ -443,7 +443,7 @@ Fill_Version(void)
 	strlcat(NGIRCd_VersionAddition, HOST_OS,
 		sizeof(NGIRCd_VersionAddition));
 
-	snprintf(NGIRCd_Version, sizeof NGIRCd_Version, "%s %s-%s",
+	snprintf(NGIRCd_Version, sizeof(NGIRCd_Version), "%s %s-%s",
 		 PACKAGE_NAME, PACKAGE_VERSION, NGIRCd_VersionAddition);
 } /* Fill_Version */
 

--- a/src/ngircd/ngircd.h
+++ b/src/ngircd/ngircd.h
@@ -29,11 +29,11 @@ GLOBAL time_t NGIRCd_Start;
 /** ngIRCd start time as string, used for RPL_CREATED_MSG (003) */
 GLOBAL char NGIRCd_StartStr[64];
 
-/** ngIRCd version number containing release number and compile-time options */
-GLOBAL char NGIRCd_Version[126];
-
 /** String specifying the compile-time options and target platform */
 GLOBAL char NGIRCd_VersionAddition[126];
+
+/** ngIRCd version number containing release number and compile-time options */
+GLOBAL char NGIRCd_Version[(sizeof(PACKAGE_NAME)-1) + 1 + (sizeof(PACKAGE_VERSION)-1) + 1 + (sizeof(NGIRCd_VersionAddition)-1) + 1];
 
 /** Flag indicating if debug mode is active (true) or not (false) */
 GLOBAL bool NGIRCd_Debug;


### PR DESCRIPTION
This patch makes these changes:
* Fix all OpenSSL deprecation warnings (Fixes #315)
* Remove support for EoL legacy OpenSSL versions (as per https://www.openssl.org/source/)
* Fix all remaining C compiler warnings
* Enable -Wall, -Wextra, -pedantic, and force them to be treated as errors with -Werror

Minor change while I was digging into the code for convenience:
* Add ctags generated 'tags' file to the .gitignore file

All tests in the bundled testsuite are passing on both GCC and clang compilers.

**Please test the DH param parsing deprecation fixes, as I don't use that feature and I'm not sure how to properly test it.**