### PR TITLE
make: install the sample config file with 0644 chmod

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -67,7 +67,7 @@ install-data-hook: $(static_docs) $(toplevel_docs) $(generated_docs)
 	 done
 
 install-config:
-	$(INSTALL) -m 600 -c sample-ngircd.conf $(DESTDIR)$(sysconfdir)/ngircd.conf
+	$(INSTALL) -m 644 -c sample-ngircd.conf $(DESTDIR)$(sysconfdir)/ngircd.conf
 	@echo; \
 	 echo " ** NOTE: Installed sample configuration file:"; \
 	 echo " ** \"$(DESTDIR)$(sysconfdir)/ngircd.conf\""; \


### PR DESCRIPTION
Some distributions (and users themselves) might simply rename the sample configuration file with 'mv' into 'ngircd.conf'. Then, when a service runner such as OpenRC or systemd runs ngircd as a different user (most likely something like _ngircd) than the one that installed the package (most likely root), ngircd fails because the file is not readable by any other user.

This change keeps the standard 0644 permissions for the sample configuration file. Users can then choose to chmod it to 0600 if their use case requires it.