### PR TITLE
Handle clients which erroneously send passwords for non-password protected servers.

### DIFF
--- a/src/ngircd/login.c
+++ b/src/ngircd/login.c
@@ -93,7 +93,8 @@ Login_User(CLIENT * Client)
 		/* Don't do any PAM authentication at all if PAM is not
 		 * enabled, instead emulate the behavior of the daemon
 		 * compiled without PAM support. */
-		if (strcmp(Conn_Password(conn), Conf_ServerPwd) == 0)
+		if (strlen(Conf_ServerPwd) == 0 || 
+			strcmp(Conn_Password(conn), Conf_ServerPwd) == 0)
 			return Login_User_PostAuth(Client);
 		Client_Reject(Client, "Bad server password", false);
 		return DISCONNECTED;
@@ -132,7 +133,8 @@ Login_User(CLIENT * Client)
 	} else return CONNECTED;
 #else
 	/* Check global server password ... */
-	if (strcmp(Conn_Password(conn), Conf_ServerPwd) != 0) {
+	if (strlen(Conf_ServerPwd) > 0 && 
+		strcmp(Conn_Password(conn), Conf_ServerPwd) != 0) {
 		/* Bad password! */
 		Client_Reject(Client, "Bad server password", false);
 		return DISCONNECTED;


### PR DESCRIPTION
Currently, ngircd always checks the password sent by the client, even for servers with no password. This is a problem for clients like DreamPassword and PlanetWeb which always send connection passwords (as far as I can tell). These clients are disconnected for giving the "wrong password", even when the server doesn't have one, because anything does not equal nothing.  This patch handles this by ignoring the password sent by the client for servers which have no password and do not use PAM.