### PR TITLE
Implement new configuration option "DefaultChannelModes"

### DIFF
--- a/doc/sample-ngircd.conf.tmpl
+++ b/doc/sample-ngircd.conf.tmpl
@@ -182,6 +182,9 @@
 	;ConnectIPv6 = yes
 	;ConnectIPv4 = yes
 
+	# Default channel mode(s) to set on new channels. Default: none.
+	;DefaultChannelModes = n
+
 	# Default user mode(s) to set on new local clients. Please note that
 	# only modes can be set that the client could set using regular MODE
 	# commands, you can't set "a" (away) for example! Default: none.

--- a/man/ngircd.conf.5.tmpl
+++ b/man/ngircd.conf.5.tmpl
@@ -274,6 +274,10 @@ Set this to no if you do not want ngIRCd to connect to other IRC servers using
 the IPv6 protocol.
 Default: yes.
 .TP
+\fBDefaultChannelModes\fR (string)
+Default channel mode(s) to set on new channels.
+Default: none.
+.TP
 \fBDefaultUserModes\fR (string)
 Default user mode(s) to set on new local clients. Please note that only modes
 can be set that the client could set using regular MODE commands, you can't

--- a/src/ngircd/conf.c
+++ b/src/ngircd/conf.c
@@ -417,6 +417,7 @@ Conf_Test( void )
 	printf("  ConnectIPv4 = %s\n", yesno_to_str(Conf_ConnectIPv6));
 	printf("  ConnectIPv6 = %s\n", yesno_to_str(Conf_ConnectIPv4));
 #endif
+	printf("  DefaultChannelModes = %s\n", Conf_DefaultChannelModes);
 	printf("  DefaultUserModes = %s\n", Conf_DefaultUserModes);
 	printf("  DNS = %s\n", yesno_to_str(Conf_DNS));
 #ifdef IDENTAUTH
@@ -810,6 +811,7 @@ Set_Defaults(bool InitServers)
 #else
 	Conf_ConnectIPv6 = false;
 #endif
+	strcpy(Conf_DefaultChannelModes, "");
 	strcpy(Conf_DefaultUserModes, "");
 	Conf_DNS = true;
 #ifdef IDENTAUTH
@@ -1652,6 +1654,30 @@ Handle_OPTIONS(const char *File, int Line, char *Var, char *Arg)
 	}
 	if (strcasecmp(Var, "ConnectIPv4") == 0) {
 		Conf_ConnectIPv4 = Check_ArgIsTrue(Arg);
+		return;
+	}
+	if (strcasecmp(Var, "DefaultChannelModes") == 0) {
+		p = Arg;
+		Conf_DefaultChannelModes[0] = '\0';
+		while (*p) {
+			if (strchr(Conf_DefaultChannelModes, *p)) {
+				/* Mode is already included; ignore it */
+				p++;
+				continue;
+			}
+
+			if (strchr(CHANMODES, *p)) {
+				len = strlen(Conf_DefaultChannelModes) + 1;
+				assert(len < sizeof(Conf_DefaultChannelModes));
+				Conf_DefaultChannelModes[len - 1] = *p;
+				Conf_DefaultChannelModes[len] = '\0';
+			} else {
+				Config_Error(LOG_WARNING,
+					     "%s, line %d: Unknown channel mode \"%c\" in \"DefaultChannelModes\"!",
+					     File, Line, *p);
+			}
+			p++;
+		}
 		return;
 	}
 	if (strcasecmp(Var, "DefaultUserModes") == 0) {

--- a/src/ngircd/conf.h
+++ b/src/ngircd/conf.h
@@ -214,6 +214,9 @@ GLOBAL char Conf_PAMServiceName[MAX_PAM_SERVICE_NAME_LEN];
 /** Disable all CTCP commands except for /me ? */
 GLOBAL bool Conf_ScrubCTCP;
 
+/** Default channel modes for new channels */
+GLOBAL char Conf_DefaultChannelModes[CHANNEL_MODE_LEN];
+
 /** Default user modes for new local clients */
 GLOBAL char Conf_DefaultUserModes[CLIENT_MODE_LEN];
 

--- a/src/ngircd/irc-channel.c
+++ b/src/ngircd/irc-channel.c
@@ -291,7 +291,7 @@ IRC_Send_Channel_Info(CLIENT *Client, CHANNEL *Chan)
 GLOBAL bool
 IRC_JOIN( CLIENT *Client, REQUEST *Req )
 {
-	char *channame, *key = NULL, *flags, *lastkey = NULL, *lastchan = NULL;
+	char *channame, *key = NULL, *flags, *lastkey = NULL, *lastchan = NULL, *p;
 	CLIENT *target;
 	CHANNEL *chan;
 
@@ -389,6 +389,14 @@ IRC_JOIN( CLIENT *Client, REQUEST *Req )
 		if (!chan) { /* channel is new; it has been created above */
 			chan = Channel_Search(channame);
 			assert(chan != NULL);
+
+			/* Set default channel modes */
+			p = Conf_DefaultChannelModes;
+			while (*p) {
+				Channel_ModeAdd(chan, *p);
+				p++;
+			}
+
 			if (Channel_IsModeless(chan)) {
 				Channel_ModeAdd(chan, 't'); /* /TOPIC not allowed */
 				Channel_ModeAdd(chan, 'n'); /* no external msgs */


### PR DESCRIPTION
The new configuration option "DefaultChannelModes" lists channel modes that become automatically set on new channels on creation.

Default: set no modes.
