### PR TITLE
defines.h: increase default NICKLEN to 31

### DIFF
--- a/src/ngircd/defines.h
+++ b/src/ngircd/defines.h
@@ -100,8 +100,8 @@
 /** Max. length of an IRC ID (incl. NULL); see RFC 2812 section 1.1 and 1.2.1. */
 #define CLIENT_ID_LEN 64
 
-/** Default nick length (including NULL), see. RFC 2812 section 1.2.1. */
-#define CLIENT_NICK_LEN_DEFAULT 10
+/** Default nick length (including NULL), see. RFC 2812 section 1.2.1. Modern servers support up to 31 */
+#define CLIENT_NICK_LEN_DEFAULT 31
 
 /** Maximum nickname length (including NULL). */
 #define CLIENT_NICK_LEN 32


### PR DESCRIPTION
The default max nick length is 9 which is too small for full name, but it looks like other servers now supports up to 31 https://modern.ircdocs.horse/#nicklen-parameter