### PR TITLE
conn: disconnect clients that send data without a command terminator (100% CPU busy-loop / remote DoS)

### DIFF
--- a/src/ngircd/conn.c
+++ b/src/ngircd/conn.c
@@ -1815,8 +1815,30 @@ Handle_Buffer(CONN_ID Idx)
 		}
 #endif
 
-		if (!ptr)
+		if (!ptr) {
+			/* No complete command (terminated by CR and/or LF) is
+			 * in the read buffer yet. But if the buffer already
+			 * holds at least a whole command's worth of data
+			 * without any line terminator at all, it can never
+			 * become a valid IRC command -- for example binary junk
+			 * or a TLS handshake sent to a plain-text listening
+			 * port. Such a connection would keep both the read
+			 * buffer non-empty and this handler (and therefore the
+			 * CPU) busy forever, because Conn_Handler() uses a zero
+			 * timeout whenever a read buffer contains COMMAND_LEN or
+			 * more bytes. So disconnect the client in this case, the
+			 * same way an over-long terminated command is handled
+			 * below: */
+			if (array_bytes(&My_Connections[Idx].rbuf) >= COMMAND_LEN) {
+				Log(LOG_ERR,
+				    "Request too long (connection %d): %d bytes without a command terminator (max. %d expected)!",
+				    Idx, array_bytes(&My_Connections[Idx].rbuf),
+				    COMMAND_LEN - 1);
+				Conn_Close(Idx, NULL, "Request too long", true);
+				return 0;
+			}
 			break;
+		}
 
 		/* Complete (=line terminated) request found, handle it! */
 		*ptr = '\0';


### PR DESCRIPTION
## Summary

`Handle_Buffer()` can be made to busy-spin at 100% CPU on a single core by any unauthenticated client that sends data containing no command terminator. A stray **TLS `ClientHello` sent to a plain-text listening port** is the most common real-world trigger (e.g. a client misconfigured to use TLS on the plain port, or an internet scanner) — but any ≥512 bytes with no CR/LF will do it. This is a remotely triggerable denial of service.

## Root cause

In `Handle_Buffer()` (`src/ngircd/conn.c`), the parser looks for a CR/LF terminator and, if it finds none, just breaks out of the loop:

```c
if (!ptr)
        break;
```

The **"Request too long" safeguard that disconnects over-long input is only reached *after* a terminator has been found** (it needs `ptr` to compute the command length). So a read buffer that contains `COMMAND_LEN` (513) or more bytes **with no CR or LF anywhere** is never drained and never closed.

Meanwhile `Conn_Handler()` sets the `io_dispatch()` timeout to **zero** whenever a read buffer holds `COMMAND_LEN` or more bytes:

```c
if (array_bytes(&My_Connections[i].rbuf) >= COMMAND_LEN) {
        io_event_del(My_Connections[i].sock, IO_WANTREAD);
        command_available = true;
        continue;
}
...
tv.tv_sec = command_available ? 0 : 1;
```

The intent is "there is already a full command to process, don't wait for the network." But when that buffer is un-parseable junk, `Handle_Buffer()` makes no progress and the buffer never shrinks, so the main loop spins with a 0-second timeout — `kevent()`/`select()` returns immediately, `Handle_Buffer()` is called again, breaks again, forever. One core sits at 100%.

Because `IO_WANTREAD` is removed for that socket, ngIRCd also never notices the client is gone, so the spin persists until the daemon is restarted.

## The fix

Apply the existing "Request too long" handling to the no-terminator case as well. If the read buffer already holds a whole command's worth of data with no terminator, it can never become a valid IRC message, so disconnect the client — exactly as an over-long *terminated* command is already handled a few lines below:

```c
if (!ptr) {
        if (array_bytes(&My_Connections[Idx].rbuf) >= COMMAND_LEN) {
                Log(LOG_ERR, "Request too long (connection %d): %d bytes "
                    "without a command terminator (max. %d expected)!", ...);
                Conn_Close(Idx, NULL, "Request too long", true);
                return 0;
        }
        break;
}
```

No false positives: a legitimate over-long command *does* contain a terminator and is still caught by the existing check below; a normal partial command under `COMMAND_LEN` bytes is left untouched to accumulate more data as before.

## Reproduction

Point ngIRCd at any plain-text port and send ≥512 bytes with no newline:

```sh
perl -e 'print "A" x 600' | nc <host> <plain-text-port>
# or, real-world: openssl s_client -connect <host>:<plain-text-port>
```

**Before:** one core jumps to 100% and stays there (a single connection is enough).
**After:** the connection is dropped immediately and CPU stays at ~0%:

```
Request too long (connection 8): 600 bytes without a command terminator (max. 512 expected)!
Connection 8 with "localhost:35206" closed (in: 0.6k, out: 0.1k).
```

## Testing

- `./autogen.sh && ./configure --with-openssl && make` — clean build.
- `make check` — full test suite passes (portability + functional server tests, 10/10 + 2/2).
- Local reproduction above confirms the connection is dropped and CPU stays flat.
- Also running in production on an OpenBSD 7.9 box (ngIRCd 27) that had been getting its CPU pegged by exactly this: real offending connections are now cleanly disconnected (observed a genuine 1467-byte `ClientHello` dropped instead of pegging a core), and load returned to normal.
